### PR TITLE
Fixes for the Scintilla syncronizer

### DIFF
--- a/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/IScintillaGateway.cs
@@ -2312,7 +2312,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>Move the selected lines down one line, shifting the line below before the selection (Scintilla feature 2621)</summary>
         void MoveSelectedLinesDown();
 
-        /// <summary>Set the identifier reported as IdFrom in notification messages. (Scintilla feature 2622)</summary>
+        /// <summary>Set the identifier reported as idFrom in notification messages. (Scintilla feature 2622)</summary>
         void SetIdentifier(int identifier);
 
         /// <summary>Get the identifier. (Scintilla feature 2623)</summary>
@@ -2464,7 +2464,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         unsafe string GetLexerLanguage();
 
         /// <summary>For private communication between an application and a known lexer. (Scintilla feature 4013)</summary>
-        int PrivateLexerCall(int operation, int pointer);
+        int PrivateLexerCall(int operation, IntPtr pointer);
 
         /// <summary>
         /// Retrieve a '\n' separated list of properties understood by the current lexer.

--- a/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/ScintillaGateway.cs
@@ -65,7 +65,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public int GetCurrentLineNumber()
         {
-            return LineFromPosition(GetCurrentPos()); 
+            return LineFromPosition(GetCurrentPos());
         }
 
         /// <summary>
@@ -308,7 +308,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public unsafe string GetCurLine(int length)
         {
-            byte[] textBuffer = new byte[10000];
+            byte[] textBuffer = new byte[length];
             fixed (byte* textPtr = textBuffer)
             {
                 IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETCURLINE, length, (IntPtr) textPtr);
@@ -1802,7 +1802,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public unsafe string GetText(int length)
         {
-            byte[] textBuffer = new byte[10000];
+            byte[] textBuffer = new byte[length];
             fixed (byte* textPtr = textBuffer)
             {
                 IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETTEXT, length, (IntPtr) textPtr);
@@ -1820,7 +1820,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>Retrieve a pointer to a function that processes messages for this Scintilla. (Scintilla feature 2184)</summary>
         public IntPtr GetDirectFunction()
         {
-            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTFUNCTION, Unused, Unused);
+            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTFUNCTION, Unused, Unused);
+            return (IntPtr) res;
         }
 
         /// <summary>
@@ -1830,7 +1831,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public IntPtr GetDirectPointer()
         {
-            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTPOINTER, Unused, Unused);
+            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDIRECTPOINTER, Unused, Unused);
+            return (IntPtr) res;
         }
 
         /// <summary>Set to overtype (true) or insert mode. (Scintilla feature 2186)</summary>
@@ -3009,7 +3011,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>Retrieve a pointer to the document object. (Scintilla feature 2357)</summary>
         public IntPtr GetDocPointer()
         {
-            return Win32.SendMessage(scintilla, SciMsg.SCI_GETDOCPOINTER, Unused, Unused);
+            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETDOCPOINTER, Unused, Unused);
+            return (IntPtr) res;
         }
 
         /// <summary>Change the document object used. (Scintilla feature 2358)</summary>
@@ -3952,7 +3955,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public IntPtr GetCharacterPointer()
         {
-            return Win32.SendMessage(scintilla, SciMsg.SCI_GETCHARACTERPOINTER, Unused, Unused);
+            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETCHARACTERPOINTER, Unused, Unused);
+            return (IntPtr) res;
         }
 
         /// <summary>
@@ -3963,7 +3967,8 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// </summary>
         public IntPtr GetRangePointer(int position, int rangeLength)
         {
-            return Win32.SendMessage(scintilla, SciMsg.SCI_GETRANGEPOINTER, position, rangeLength);
+            IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_GETRANGEPOINTER, position, rangeLength);
+            return (IntPtr) res;
         }
 
         /// <summary>
@@ -4628,7 +4633,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
             IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_MOVESELECTEDLINESDOWN, Unused, Unused);
         }
 
-        /// <summary>Set the identifier reported as IdFrom in notification messages. (Scintilla feature 2622)</summary>
+        /// <summary>Set the identifier reported as idFrom in notification messages. (Scintilla feature 2622)</summary>
         public void SetIdentifier(int identifier)
         {
             IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_SETIDENTIFIER, identifier, Unused);
@@ -4968,7 +4973,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         }
 
         /// <summary>For private communication between an application and a known lexer. (Scintilla feature 4013)</summary>
-        public int PrivateLexerCall(int operation, int pointer)
+        public int PrivateLexerCall(int operation, IntPtr pointer)
         {
             IntPtr res = Win32.SendMessage(scintilla, SciMsg.SCI_PRIVATELEXERCALL, operation, pointer);
             return (int) res;

--- a/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
+++ b/Visual Studio Project Template C#/PluginInfrastructure/Scintilla_iface.cs
@@ -21,7 +21,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>
         /// environment specific window handle/pointer
         /// </summary>
-        public IntPtr hwndFrom; 
+        public IntPtr hwndFrom;
 
         /// <summary>
         /// CtrlID of the window issuing the notification
@@ -31,7 +31,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// <summary>
         /// The SCN_* notification Code
         /// </summary>
-        public uint Code;       
+        public uint Code;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -2549,7 +2549,7 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         /// Move the selected lines down one line, shifting the line below before the selection
         SCI_MOVESELECTEDLINESDOWN = 2621,
 
-        /// Set the identifier reported as IdFrom in notification messages.
+        /// Set the identifier reported as idFrom in notification messages.
         SCI_SETIDENTIFIER = 2622,
 
         /// Get the identifier.


### PR DESCRIPTION
* Sets IntPtr where needed
* use 'length' parameters as buffer size (GetText, GetCurLine)

Includes newly generated files